### PR TITLE
Fix record stack bug

### DIFF
--- a/gemini20-canvas/index.html
+++ b/gemini20-canvas/index.html
@@ -322,6 +322,7 @@
 
             webSocket.send(JSON.stringify(payload));
             console.log("sent: ", payload);
+            stopAudioInput();
         }
 
         function receiveMessage(event) {

--- a/gemini20-canvas/index.html
+++ b/gemini20-canvas/index.html
@@ -141,9 +141,6 @@
                               class="mdl-button mdl-js-button mdl-button--fab mdl-button--mini-fab mdl-button--colored">
                            <i class="material-icons">mic</i>
                         </button>
-                        <button id="stopButton" class="mdl-button mdl-js-button mdl-button--fab mdl-button--mini-fab">
-                           <i class="material-icons">mic_off</i>
-                        </button>
                        </div>
                       </div>
                          <!-- Drawing Canvas -->
@@ -162,7 +159,6 @@
         const imageLoader = document.getElementById('imageLoader');
          const clearButton = document.getElementById('clearButton');
         const startButton = document.getElementById('startButton');
-        const stopButton = document.getElementById('stopButton');
          const brushSizeInput = document.getElementById('brushSize');
          const brushColorInput = document.getElementById('brushColor');
 
@@ -455,7 +451,6 @@
         }
 
         startButton.addEventListener('click', startAudioInput);
-        stopButton.addEventListener('click', stopAudioInput);
 
 
         class Response {

--- a/gemini20-rag/index.html
+++ b/gemini20-rag/index.html
@@ -277,6 +277,7 @@
 
                 webSocket.send(JSON.stringify(payload));
                 console.log("sent payload with audio data");
+                stopAudioInput();
             }
             catch (err) {
                 console.error("Error sending audio message:", err);

--- a/gemini20-rag/index.html
+++ b/gemini20-rag/index.html
@@ -111,10 +111,6 @@
                                 class="mdl-button mdl-js-button mdl-button--fab mdl-button--mini-fab mdl-button--colored">
                                 <i class="material-icons">mic</i>
                             </button>
-                            <button id="stopButton"
-                                class="mdl-button mdl-js-button mdl-button--fab mdl-button--mini-fab">
-                                <i class="material-icons">mic_off</i>
-                            </button>
                         </div>
 
                         <!-- PDF Upload -->
@@ -419,7 +415,6 @@
         }
 
         startButton.addEventListener('click', startAudioInput);
-        stopButton.addEventListener('click', stopAudioInput);
 
         class Response {
             constructor(data) {

--- a/gemini20-realtime-function/index.html
+++ b/gemini20-realtime-function/index.html
@@ -180,6 +180,7 @@
 
             webSocket.send(JSON.stringify(payload));
             console.log("sent: ", payload);
+            stopAudioInput();
         }
 
         function receiveMessage(event) {

--- a/gemini20-realtime-function/index.html
+++ b/gemini20-realtime-function/index.html
@@ -47,10 +47,6 @@
                             class="mdl-button mdl-js-button mdl-button--fab mdl-button--mini-fab mdl-button--colored">
                             <i class="material-icons">mic</i>
                         </button>
-                        <button id="stopButton"
-                            class="mdl-button mdl-js-button mdl-button--fab mdl-button--mini-fab">
-                            <i class="material-icons">mic_off</i>
-                        </button>
                     </div>
 
                     <!-- Video Element -->
@@ -71,7 +67,6 @@
         const canvas = document.getElementById("canvasElement");
         const context = canvas.getContext("2d");
         const startButton = document.getElementById('startButton');
-        const stopButton = document.getElementById('stopButton');
         let stream = null;
         let currentFrameB64;
         let webSocket = null;
@@ -318,7 +313,6 @@
         }
 
         startButton.addEventListener('click', startAudioInput);
-        stopButton.addEventListener('click', stopAudioInput);
 
 
         class Response {

--- a/gemini20-realtime/index.html
+++ b/gemini20-realtime/index.html
@@ -180,6 +180,7 @@
 
             webSocket.send(JSON.stringify(payload));
             console.log("sent: ", payload);
+            stopAudioInput();
         }
 
         function receiveMessage(event) {

--- a/gemini20-realtime/index.html
+++ b/gemini20-realtime/index.html
@@ -47,10 +47,6 @@
                             class="mdl-button mdl-js-button mdl-button--fab mdl-button--mini-fab mdl-button--colored">
                             <i class="material-icons">mic</i>
                         </button>
-                        <button id="stopButton"
-                            class="mdl-button mdl-js-button mdl-button--fab mdl-button--mini-fab">
-                            <i class="material-icons">mic_off</i>
-                        </button>
                     </div>
 
                     <!-- Video Element -->
@@ -71,7 +67,6 @@
         const canvas = document.getElementById("canvasElement");
         const context = canvas.getContext("2d");
         const startButton = document.getElementById('startButton');
-        const stopButton = document.getElementById('stopButton');
         let stream = null;
         let currentFrameB64;
         let webSocket = null;
@@ -318,7 +313,6 @@
         }
 
         startButton.addEventListener('click', startAudioInput);
-        stopButton.addEventListener('click', stopAudioInput);
 
 
         class Response {

--- a/gemini20-screen/index.html
+++ b/gemini20-screen/index.html
@@ -49,10 +49,6 @@
                             class="mdl-button mdl-js-button mdl-button--fab mdl-button--mini-fab mdl-button--colored">
                             <i class="material-icons">mic</i>
                         </button>
-                        <button id="stopButton"
-                            class="mdl-button mdl-js-button mdl-button--fab mdl-button--mini-fab">
-                            <i class="material-icons">mic_off</i>
-                        </button>
                     </div>
 
                     <!-- Video Element -->
@@ -80,7 +76,6 @@
         });
 
         const startButton = document.getElementById('startButton');
-        const stopButton = document.getElementById('stopButton');
         let stream = null;
         let currentFrameB64;
         let webSocket = null;
@@ -337,7 +332,6 @@
         }
 
         startButton.addEventListener('click', startAudioInput);
-        stopButton.addEventListener('click', stopAudioInput);
 
 
         class Response {

--- a/gemini20-screen/index.html
+++ b/gemini20-screen/index.html
@@ -201,6 +201,7 @@
 
             webSocket.send(JSON.stringify(payload));
             console.log("sent: ", payload);
+            stopAudioInput();
         }
 
         function receiveMessage(event) {

--- a/gemini20-voicetext/index.html
+++ b/gemini20-voicetext/index.html
@@ -235,6 +235,7 @@
 
             webSocket.send(JSON.stringify(payload));
             console.log("sent: ", payload);
+            stopAudioInput();
         }
 
         function receiveMessage(event) {

--- a/gemini20-voicetext/index.html
+++ b/gemini20-voicetext/index.html
@@ -81,10 +81,6 @@
                                 class="mdl-button mdl-js-button mdl-button--fab mdl-button--mini-fab mdl-button--colored">
                                 <i class="material-icons">mic</i>
                             </button>
-                            <button id="stopButton"
-                                class="mdl-button mdl-js-button mdl-button--fab mdl-button--mini-fab">
-                                <i class="material-icons">mic_off</i>
-                            </button>
                         </div>
 
                         <!-- Video Element -->
@@ -114,7 +110,6 @@
         });
 
         const startButton = document.getElementById('startButton');
-        const stopButton = document.getElementById('stopButton');
         let stream = null;
         let currentFrameB64;
         let webSocket = null;
@@ -371,7 +366,6 @@
         }
 
         startButton.addEventListener('click', startAudioInput);
-        stopButton.addEventListener('click', stopAudioInput);
 
 
         class Response {


### PR DESCRIPTION
**Current state:**
1. In all of Gemini's real time voice chat there is a `startButton` and a `stopButton` for start and stop the record
2. When using the GUI for pressing the buttons it is required from the user to press the `stopButton` each time at a specific time
3. If the user fails to press it - the chat is basically over due to the fact that the user cannot talk anymore due to maximum call stack

**After the PR**
1. Everything remain the same, but the `stopAudioInput` is automatically called at the end of the record, so the stopButton press is not needed
2. Removed the stopButton code and UI  element